### PR TITLE
Changed ActionUpdateThread.EDT to ActionUpdateThread.BGT

### DIFF
--- a/src/main/java/com/sburlyaev/cmd/plugin/actions/OpenSelectedDirectoryAction.java
+++ b/src/main/java/com/sburlyaev/cmd/plugin/actions/OpenSelectedDirectoryAction.java
@@ -1,7 +1,6 @@
 package com.sburlyaev.cmd.plugin.actions;
 
 import com.intellij.ide.actions.RevealFileAction;
-import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.project.Project;
@@ -40,10 +39,5 @@ public class OpenSelectedDirectoryAction extends OpenTerminalBaseAction {
         return file != null
                 ? file.isDirectory() ? file : file.getParent()
                 : null;
-    }
-
-    @Override
-    public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.EDT;
     }
 }

--- a/src/main/java/com/sburlyaev/cmd/plugin/actions/OpenTerminalBaseAction.java
+++ b/src/main/java/com/sburlyaev/cmd/plugin/actions/OpenTerminalBaseAction.java
@@ -1,5 +1,6 @@
 package com.sburlyaev.cmd.plugin.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAwareAction;
@@ -8,8 +9,9 @@ import com.sburlyaev.cmd.plugin.model.Command;
 import com.sburlyaev.cmd.plugin.model.Environment;
 import com.sburlyaev.cmd.plugin.settings.PluginSettings;
 import com.sburlyaev.cmd.plugin.settings.PluginSettingsState;
-import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
 
 public abstract class OpenTerminalBaseAction extends DumbAwareAction {
 
@@ -54,4 +56,8 @@ public abstract class OpenTerminalBaseAction extends DumbAwareAction {
         return envFavoriteTerminal;
     }
 
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
 }

--- a/src/main/java/com/sburlyaev/cmd/plugin/actions/SetAsDefaultDirectoryAction.java
+++ b/src/main/java/com/sburlyaev/cmd/plugin/actions/SetAsDefaultDirectoryAction.java
@@ -53,6 +53,6 @@ public class SetAsDefaultDirectoryAction extends DumbAwareAction {
 
     @Override
     public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.EDT;
+        return ActionUpdateThread.BGT;
     }
 }


### PR DESCRIPTION
Hey, in my last PR I've made an error to think that OLD_EDT ist the new EDT.
After plugin update the folder context menu entry for Native Terminal has disappeared